### PR TITLE
Add link text to printf

### DIFF
--- a/dino-chat-export.sh
+++ b/dino-chat-export.sh
@@ -231,7 +231,7 @@ message_slots_to_selection() {
 							WHEN (file_transfer.path LIKE '%.jpg') OR (file_transfer.path LIKE '%.jpeg') OR (file_transfer.path LIKE '%.jpeg')
 									OR (file_transfer.path LIKE '%.png') OR (file_transfer.path LIKE '%.webm') OR (file_transfer.path LIKE '%.svg')
 								THEN PRINTF('$IMAGE_FORMAT', 'files/' || path)
-								ELSE PRINTF('$FILE_FORMAT', 'files/' || path)
+								ELSE PRINTF('$FILE_FORMAT', 'files/' || path, 'files/' || path)
 						END
 						FROM file_transfer
 						WHERE file_transfer.info == message.id )


### PR DESCRIPTION
Adds link text for the following
`FILE_FORMAT='<a href="%s" />%s</a>'`

links for files are missing by default, so this would fix that.